### PR TITLE
Add repository field to readme

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,9 @@
     "release": "stop && mandate",
     "postrelease": "rimraf out",
     "test": "mocha -R spec"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ForbesLindesay/promisejs.org.git"
   }
 }


### PR DESCRIPTION
I am a bot.  I add repository fields to package.json files because they're super useful for npm.
