### PR TITLE
Use Promise.resolve in "all" pattern

### DIFF
--- a/views/patterns.jade
+++ b/views/patterns.jade
@@ -131,10 +131,10 @@ block content
     :js
       function all(promises) {
         var accumulator = [];
-        var ready = Promise.from(null);
+        var ready = Promise.resolve(null);
 
         promises.forEach(function (promise) {
-          ready = ready.then(function (acc) {
+          ready = ready.then(function () {
             return promise;
           }).then(function (value) {
             accumulator.push(value);


### PR DESCRIPTION
Uses `Promise.resolve` in the `all` pattern example. Former example made use of `Promise.from` to get a resolved promise, which is no longer in the specification nor implemented by browsers.

Removes an unused function parameter in the same code snippet.
