### PR TITLE
Fix name of link

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -206,7 +206,7 @@ block content
 
     p.
       Promises are currently only supported by a pretty small selection of browsers
-      (#[a(href="http://kangax.github.io/es5-compat-table/es6/#Promise") see kangax compatability tables]).
+      (#[a(href="http://kangax.github.io/es5-compat-table/es6/#Promise") see kangax compatibility tables]).
       The good news is that they're extremely easy to polyfill (#[a(href="/polyfills/promise-" + versions.promise + ".min.js") minified] / #[a(href="/polyfills/promise-" + versions.promise + ".js") unminified]):
     .small-code
       :html


### PR DESCRIPTION
This Pull request fixes the name of compatibility tables link.
