### PR TITLE
Adds missing handlers calls

### DIFF
--- a/views/implementing.jade
+++ b/views/implementing.jade
@@ -57,11 +57,17 @@ block content
         function fulfill(result) {
           state = FULFILLED;
           value = result;
+          
+          handlers.forEach(handle);
+          handlers = null;
         }
 
         function reject(error) {
           state = REJECTED;
           value = error;
+          
+          handlers.forEach(handle);
+          handlers = null;
         }
       }
 
@@ -87,11 +93,17 @@ block content
         function fulfill(result) {
           state = FULFILLED;
           value = result;
+          
+          handlers.forEach(handle);
+          handlers = null;
         }
 
         function reject(error) {
           state = REJECTED;
           value = error;
+          
+          handlers.forEach(handle);
+          handlers = null;
         }
 
         function resolve(result) {


### PR DESCRIPTION
This implementations currently doesn't work, because `onFulfilled` and `onRejected` handlers aren't call during the final `resolve`. This patch just fix the missing calls according to the original post on SO. (http://stackoverflow.com/questions/23772801/basic-javascript-promise-implementation-attempt/23785244#23785244)