### PR TITLE
Improves implementing page readability

### DIFF
--- a/views/implementing.jade
+++ b/views/implementing.jade
@@ -248,7 +248,6 @@ block content
         }
       }
 
-      // set fulfill/reject callbacks
       this.done = function (onFulfilled, onRejected) {
         // ensure we are always asynchronous
         setTimeout(function () {
@@ -316,8 +315,7 @@ block content
         });
       }
 
-    p.
-      Finally, the whole implementation.
+    h2#allcode The whole implementation
 
     :js
       var PENDING = 0;
@@ -337,6 +335,8 @@ block content
         function fulfill(result) {
           state = FULFILLED;
           value = result;
+
+          // runs handlers and resets queue
           handlers.forEach(handle);
           handlers = null;
         }
@@ -344,6 +344,8 @@ block content
         function reject(error) {
           state = REJECTED;
           value = error;
+
+          // runs handlers and resets queue
           handlers.forEach(handle);
           handlers = null;
         }
@@ -361,6 +363,7 @@ block content
           }
         }
 
+        // manages handlers according to Promise state
         function handle(handler) {
           if (state === PENDING) {
             handlers.push(handler);

--- a/views/implementing.jade
+++ b/views/implementing.jade
@@ -232,78 +232,55 @@ block content
       li it is called regardless of whether the promise is resolved before or after we call #[code .done]
 
     :js
-      var PENDING = 0;
-      var FULFILLED = 1;
-      var REJECTED = 2;
-
-      function Promise(fn) {
-        // store state which can be PENDING, FULFILLED or REJECTED
-        var state = PENDING;
-
-        // store value once FULFILLED or REJECTED
-        var value = null;
-
-        // store sucess & failure handlers
-        var handlers = [];
-
-        function fulfill(result) {
-          state = FULFILLED;
-          value = result;
-          handlers.forEach(handle);
-          handlers = null;
-        }
-
-        function reject(error) {
-          state = REJECTED;
-          value = error;
-          handlers.forEach(handle);
-          handlers = null;
-        }
-
-        function resolve(result) {
-          try {
-            var then = getThen(result);
-            if (then) {
-              doResolve(then.bind(result), resolve, reject)
-              return
-            }
-            fulfill(result);
-          } catch (e) {
-            reject(e);
+      // manages handlers according to Promise state
+      function handle(handler) {
+        if (state === PENDING) {
+          handlers.push(handler);
+        } else {
+          if (state === FULFILLED &&
+            typeof handler.onFulfilled === 'function') {
+            handler.onFulfilled(value);
+          }
+          if (state === REJECTED &&
+            typeof handler.onRejected === 'function') {
+            handler.onRejected(value);
           }
         }
+      }
 
-        function handle(handler) {
-          if (state === PENDING) {
-            handlers.push(handler);
-          } else {
-            if (state === FULFILLED &&
-              typeof handler.onFulfilled === 'function') {
-              handler.onFulfilled(value);
-            }
-            if (state === REJECTED &&
-              typeof handler.onRejected === 'function') {
-              handler.onRejected(value);
-            }
-          }
-        }
-
-        this.done = function (onFulfilled, onRejected) {
-          // ensure we are always asynchronous
-          setTimeout(function () {
-            handle({
-              onFulfilled: onFulfilled,
-              onRejected: onRejected
-            });
-          }, 0);
-        }
-
-        doResolve(fn, resolve, reject);
+      // set fulfill/reject callbacks
+      this.done = function (onFulfilled, onRejected) {
+        // ensure we are always asynchronous
+        setTimeout(function () {
+          handle({
+            onFulfilled: onFulfilled,
+            onRejected: onRejected
+          });
+        }, 0);
       }
 
     p.
       We make sure to notify the handlers when the Promise is resolved or rejected.
-      We only ever do this in the next tick.
+      We only ever do this in the next tick by removes them from the queue.
+
+    :js
+      function fulfill(result) {
+        state = FULFILLED;
+        value = result;
+
+        // runs handlers and resets queue
+        handlers.forEach(handle);
+        handlers = null;
+      }
+
+      function reject(error) {
+        state = REJECTED;
+        value = error;
+
+        // runs handlers and resets queue
+        handlers.forEach(handle);
+        handlers = null;
+      }
 
     h2#then Observing (via .then)
 

--- a/views/implementing.jade
+++ b/views/implementing.jade
@@ -270,7 +270,7 @@ block content
 
         // runs handlers and resets queue
         handlers.forEach(handle);
-        handlers = null;
+        handlers = [];
       }
 
       function reject(error) {
@@ -279,7 +279,7 @@ block content
 
         // runs handlers and resets queue
         handlers.forEach(handle);
-        handlers = null;
+        handlers = [];
       }
 
     h2#then Observing (via .then)

--- a/views/implementing.jade
+++ b/views/implementing.jade
@@ -154,10 +154,10 @@ block content
             done = true
             onRejected(reason)
           })
-        } catch (ex) {
+        } catch (e) {
           if (done) return
           done = true
-          onRejected(ex)
+          onRejected(e)
         }
       }
 
@@ -296,8 +296,8 @@ block content
             if (typeof onFulfilled === 'function') {
               try {
                 return resolve(onFulfilled(result));
-              } catch (ex) {
-                return reject(ex);
+              } catch (e) {
+                return reject(e);
               }
             } else {
               return resolve(result);
@@ -306,8 +306,8 @@ block content
             if (typeof onRejected === 'function') {
               try {
                 return resolve(onRejected(error));
-              } catch (ex) {
-                return reject(ex);
+              } catch (e) {
+                return reject(e);
               }
             } else {
               return reject(error);
@@ -393,8 +393,8 @@ block content
               if (typeof onFulfilled === 'function') {
                 try {
                   return resolve(onFulfilled(result));
-                } catch (ex) {
-                  return reject(ex);
+                } catch (e) {
+                  return reject(e);
                 }
               } else {
                 return resolve(result);
@@ -403,8 +403,8 @@ block content
               if (typeof onRejected === 'function') {
                 try {
                   return resolve(onRejected(error));
-                } catch (ex) {
-                  return reject(ex);
+                } catch (e) {
+                  return reject(e);
                 }
               } else {
                 return reject(error);

--- a/views/implementing.jade
+++ b/views/implementing.jade
@@ -339,6 +339,106 @@ block content
         });
       }
 
+    p.
+      Finally, the whole implementation.
+
+    :js
+      var PENDING = 0;
+      var FULFILLED = 1;
+      var REJECTED = 2;
+
+      function Promise(fn) {
+        // store state which can be PENDING, FULFILLED or REJECTED
+        var state = PENDING;
+
+        // store value once FULFILLED or REJECTED
+        var value = null;
+
+        // store sucess & failure handlers
+        var handlers = [];
+
+        function fulfill(result) {
+          state = FULFILLED;
+          value = result;
+          handlers.forEach(handle);
+          handlers = null;
+        }
+
+        function reject(error) {
+          state = REJECTED;
+          value = error;
+          handlers.forEach(handle);
+          handlers = null;
+        }
+
+        function resolve(result) {
+          try {
+            var then = getThen(result);
+            if (then) {
+              doResolve(then.bind(result), resolve, reject)
+              return
+            }
+            fulfill(result);
+          } catch (e) {
+            reject(e);
+          }
+        }
+
+        function handle(handler) {
+          if (state === PENDING) {
+            handlers.push(handler);
+          } else {
+            if (state === FULFILLED &&
+              typeof handler.onFulfilled === 'function') {
+              handler.onFulfilled(value);
+            }
+            if (state === REJECTED &&
+              typeof handler.onRejected === 'function') {
+              handler.onRejected(value);
+            }
+          }
+        }
+
+        this.done = function (onFulfilled, onRejected) {
+          // ensure we are always asynchronous
+          setTimeout(function () {
+            handle({
+              onFulfilled: onFulfilled,
+              onRejected: onRejected
+            });
+          }, 0);
+        }
+
+        this.then = function (onFulfilled, onRejected) {
+          var self = this;
+          return new Promise(function (resolve, reject) {
+            return self.done(function (result) {
+              if (typeof onFulfilled === 'function') {
+                try {
+                  return resolve(onFulfilled(result));
+                } catch (ex) {
+                  return reject(ex);
+                }
+              } else {
+                return resolve(result);
+              }
+            }, function (error) {
+              if (typeof onRejected === 'function') {
+                try {
+                  return resolve(onRejected(error));
+                } catch (ex) {
+                  return reject(ex);
+                }
+              } else {
+                return reject(error);
+              }
+            });
+          });
+        }
+
+        doResolve(fn, resolve, reject);
+      }
+
     h2#apendix Further Reading
 
     ul


### PR DESCRIPTION
As discussed in [#36](https://github.com/ForbesLindesay/promisejs.org/pull/36), I propose to split the `Observing (via .done)` chapter and add the whole implementation at the end. I find it clearer that way.
