### PR TITLE
Promise.all returns array of results in order

### DIFF
--- a/views/patterns.jade
+++ b/views/patterns.jade
@@ -133,11 +133,11 @@ block content
         var accumulator = [];
         var ready = Promise.resolve(null);
 
-        promises.forEach(function (promise) {
+        promises.forEach(function (promise, ndx) {
           ready = ready.then(function () {
             return promise;
           }).then(function (value) {
-            accumulator.push(value);
+            accumulator[ndx] = value;
           });
         });
 


### PR DESCRIPTION
Doesn't `Promise.all` return the results in the same order? Otherwise if it returns then in order of the completion of the promises it seems like it would be pretty hard to use.