### PR TITLE
Rearrange the order of the plugins transforming @foo and :foo

### DIFF
--- a/content.js
+++ b/content.js
@@ -57,19 +57,6 @@ module.exports = function getContent(url, options) {
       plugins.push({regexp: regexp, replacer: replacer});
     }
     plugin(
-      /\:([a-z\-]+)((?:\n(?:  .*)?)*)/g,
-      function (_, name, content) {
-        return require('./components/' + name)({
-          content: content.split('\n').map(function (line) {
-            return line.substr(line.length >= 2 ? 2 : 0);
-          }).join('\n').trim()
-        }, {
-          read: read,
-          render: render
-        });
-      }
-    );
-    plugin(
       /\@([a-z\-]+)(\(.*\))?((?:\n(?:  .*)?)*)/g,
       function (_, name, attrs, content) {
         return require('./components/' + name)({
@@ -79,6 +66,19 @@ module.exports = function getContent(url, options) {
               return line.substr(line.length >= 2 ? 2 : 0);
             }).join('\n').trim()
           )
+        }, {
+          read: read,
+          render: render
+        });
+      }
+    );
+    plugin(
+      /\:([a-z\-]+)((?:\n(?:  .*)?)*)/g,
+      function (_, name, content) {
+        return require('./components/' + name)({
+          content: content.split('\n').map(function (line) {
+            return line.substr(line.length >= 2 ? 2 : 0);
+          }).join('\n').trim()
         }, {
           read: read,
           render: render


### PR DESCRIPTION
This way we can handle the case where we have :html inside @panel-danger

This fixes the problem in the index page where the phrase "undefined" was shown instead of script-tag. Use "find in page" and search for "undefined" at https://www.promisejs.org/