### PR TITLE
change import to include (layout.jade; fbpixel)

### DIFF
--- a/views/layout.jade
+++ b/views/layout.jade
@@ -55,4 +55,4 @@ html(lang=(locale && translated) ? locale: 'en')
       c.appendChild(s);
       }(d, document.createElement('script')));
       }, 1000);
-    import ./fbpixel.html
+    include ./fbpixel.html


### PR DESCRIPTION
'import' keyword in layout.jade template was presumably intended to be 'include' so as to include the contents of fbpixel.html in the rendered page.